### PR TITLE
Switch to URL path-based identifiers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8

--- a/index.html
+++ b/index.html
@@ -97,8 +97,8 @@
         <dd>an HTTP resource that supports operations to create a new
         transaction</dd>
         <dt>transaction identifier</dt>
-        <dd>an HTTP resource that uniquely identifies a trasnaction, and which
-        may be used to perform operations on that transaction</dd>
+        <dd>a URI that uniquely identifies a transaction, and which may be used
+        to perform operations on that transaction</dd>
       </dl>
     </section>
     <section id ="atomic-operations">
@@ -116,7 +116,7 @@
           HEAD http://example.org/repo
 
           200 OK
-          Link: &lt;http://example.org/repo/fcr:tx>; rel="[URI TBD]"
+          Link: &lt;http://example.org/repo/fcr:tx>; rel="http://fedora.info/definitions/v4/transaction#endpoint"
 
           # Begin a transaction
 
@@ -204,7 +204,7 @@
           identifier as the value of the <code>Atomic-ID</code> header, as
           described here, until the series expires or is finished. The effect of
           the request, if it has one, and if the request is successful, SHOULD
-          NOT be visible to clients not using that transaction identifier The
+          NOT be visible to clients not using that transaction identifier. The
           effect of the request MUST NOT be durable unless and until the series
           is successfully <a href="#commit">finished</a>.
         </p>
@@ -247,9 +247,12 @@
           <code>PUT</code> request to the transaction identifier URI.
         </p>
         <p>
-          The request body of this request MAY be non-empty. If it is non-empty,
-          [TODO: should we specify? or leave it up to implementations; this
-          could be a place to include commit messages, author info, etc.]
+          The request body of this request MUST be a JSON document with at least
+          the single key `state` with the value `committed`. Implementations MAY
+          include additional keys in this JSON document. The interpretation of
+          those keys and their values is outside the scope of this
+          specififcation. A server MUST ignore keys in the JSON document that it
+          does not recognize.
         </p>
         <p>
           The effects of all requests in the series MUST become durable and MUST

--- a/index.html
+++ b/index.html
@@ -235,6 +235,14 @@
           server MAY also include more information about the reason for
           rejecting the request in the response body.
         </p>
+        <p>
+          A server MAY choose to reject certain operations it normally supports
+          when it receives those requests with an <code>Atomic-ID</code>. If
+          this is the case, the server MUST respond to those requests with a
+          <code>403 Forbidden</code> HTTP status. The server MAY also include
+          more infromation about the reason for rejecting the request in the
+          response body.
+        </p>
       </section>
 
       <section id="expiration">

--- a/index.html
+++ b/index.html
@@ -94,8 +94,7 @@
       <h2>Terminology</h2>
       <dl>
         <dt>transaction endpoint</dt>
-        <dd>an HTTP resource that supports operations to create a new
-        transaction</dd>
+        <dd>a URI that supports operations to create a new transaction</dd>
         <dt>transaction identifier</dt>
         <dd>a URI that uniquely identifies a transaction, and which may be used
         to perform operations on that transaction</dd>
@@ -165,7 +164,7 @@
         <h2>Transaction endpoint</h2>
         <p>
           Transactions are created through a <dfn>transaction endpoint</dfn>.
-          The <dfn>transaction endpoint URI</dfn> MUST be a resolvable HTTP URI.
+          The transaction endpoint MUST be a resolvable HTTP URI.
         </p>
         <p>
           A server that supports atomic operations MUST advertise this support
@@ -195,8 +194,8 @@
         <h2>Adding to an atomic series of operations</h2>
         <p>
           A client adds to an atomic batch operation by including an
-          <code>Atomic-ID</code> request header. The value of this header is a
-          transaction identifier.
+          <code>Atomic-ID</code> request header to its request. The value of
+          this header is a transaction identifier.
         </p>
         <p>
           The effect of the request, if it has one, and if the request is
@@ -209,7 +208,7 @@
           is successfully <a href="#commit">finished</a>.
         </p>
         <p>
-          If the request is successful, the server MUST include a
+          If the request is successful, the server MUST include an
           <code>Atomic-ID</code> response header whose value MUST be the current
           transaction identifier.
         </p>
@@ -238,6 +237,19 @@
         <p>
           An implementation SHOULD permit extending the lifetime of a series by
           a <code>POST</code> request to the transaction identifier URI.
+          If an implementation supports extending the lifetime of a series, and
+          is able to successfully update the transaction, it MUST respond with a
+          <code>204 No Content</code> HTTP status. It MUST also include an
+          <code>Atomic-Expires</code> header in the response with the new HTTP
+          datetime at which the series will expire.
+        </p>
+        <p>
+          If the server supports extending the lifetime of series in general,
+          but is unable to do so for a particular instance, it MUST respond with
+          a <code>409 Conflict</code> HTTP status. The server MAY also include
+          more information in the body of the response describing the reason for
+          not extending the lifetime of the transaction.
+        </p>
       </section>
 
       <section id="commit">

--- a/index.html
+++ b/index.html
@@ -98,6 +98,9 @@
         <dt>transaction identifier</dt>
         <dd>a URI that uniquely identifies a transaction, and which may be used
         to perform operations on that transaction</dd>
+        <dt>commit endpoint</dt>
+        <dd>a URI that a client uses to indicate that they are finishing a
+        transaction and they wish their changes to become durable</dd>
       </dl>
     </section>
     <section id ="atomic-operations">
@@ -115,46 +118,51 @@
           HEAD http://example.org/repo
 
           200 OK
-          Link: &lt;http://example.org/repo/fcr:tx>; rel="http://fedora.info/definitions/v4/transaction#endpoint"
+          Link: &lt;http://example.org/repo/fcr:tx>;
+                rel="http://fedora.info/definitions/v4/transaction#endpoint"
 
           # Begin a transaction
 
           POST http://example.org/repo/fcr:tx
 
           201 Created
-          Location: http://example.org/repo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+          Location: http://example.org/repo/fcr:tx/13423c37-2e36-425e-a126-9025e2da7aae
+          Link: &lt;http://example.org/repo/fcr:tx/13423c37-2e36-425e-a126-9025e2da7aae/commit;
+                rel="http://fedora.info/definitions/v4/transaction#commitEndpoint"
 
           # Create a new resource within the transaction
 
           POST http://example.org/repo/container
-          Atomic-ID: http://example.org/repo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+          Slug: foobar
+          Atomic-ID: http://example.org/repo/fcr:tx/13423c37-2e36-425e-a126-9025e2da7aae
 
           201 Created
-          Location: http://example.org/repo/container/abcdef01-2345-6789-abcd-ef0123456789
-          Atomic-ID: http://example.org/repo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+          Location: http://example.org/repo/container/foobar
+          Atomic-ID: http://example.org/repo/fcr:tx/13423c37-2e36-425e-a126-9025e2da7aae
 
           # That resource is not visible outside of the transaction
 
-          HEAD http://example.org/repo/container/abcdef01-2345-6789-abcd-ef0123456789
+          HEAD http://example.org/repo/container/foobar
 
           404 Not Found
 
           # But is visible within the transaction
 
-          HEAD http://example.org/repo/container/abcdef01-2345-6789-abcd-ef0123456789
-          Atomic-ID: http://example.org/repo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+          HEAD http://example.org/repo/container/foobar
+          Atomic-ID: http://example.org/repo/fcr:tx/13423c37-2e36-425e-a126-9025e2da7aae
 
           200 OK
 
           # Commit the transaction
 
-          PUT http://example.org/repo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+          PUT
+          http://example.org/repo/fcr:tx/13423c37-2e36-425e-a126-9025e2da7aae/commit
 
           204 No Content
 
           # Now the new resource is visible outside the transaction
 
-          HEAD http://example.org/repo/container/abcdef01-2345-6789-abcd-ef0123456789
+          HEAD http://example.org/repo/container/foobar
 
           200 OK
         </pre>
@@ -188,6 +196,13 @@
           identifier</dfn>. A transaction identifier MUST be a resolvable HTTP
           URI.
         </p>
+        <p>
+          A server MUST also include a <code>Link</code> header in its response.
+          The value of this link MUST be a <dfn>commit endpoint</dfn>. The
+          <code>rel</code> parameter of this header MUST be
+          <code>http://fedora.info/definitions/v4/transaction#commitEndpoint</code>.
+          A commit endpoint MUST be a resolvable HTTP URI.
+        </p>
       </section>
 
       <section id="adding">
@@ -201,11 +216,12 @@
           The effect of the request, if it has one, and if the request is
           successful, MUST be visible to clients using the same transaction
           identifier as the value of the <code>Atomic-ID</code> header, as
-          described here, until the series expires or is finished. The effect of
-          the request, if it has one, and if the request is successful, SHOULD
-          NOT be visible to clients not using that transaction identifier. The
-          effect of the request MUST NOT be durable unless and until the series
-          is successfully <a href="#commit">finished</a>.
+          described here, until the series <a href="#expiration">expires</a> or
+          is <a href="#commit">finished</a>. The effect of the request, if it
+          has one, and if the request is successful, SHOULD NOT be visible to
+          clients not using that transaction identifier. The effect of the
+          request MUST NOT be durable unless and until the series is
+          successfully <a href="#commit">finished</a>.
         </p>
         <p>
           If the request is successful, the server MUST include an
@@ -256,15 +272,7 @@
         <h2>Committing a series</h2>
         <p>
           A client finishes an atomic series of requests by sending a
-          <code>PUT</code> request to the transaction identifier URI.
-        </p>
-        <p>
-          The request body of this request MUST be a JSON document with at least
-          the single key `state` with the value `committed`. Implementations MAY
-          include additional keys in this JSON document. The interpretation of
-          those keys and their values is outside the scope of this
-          specififcation. A server MUST ignore keys in the JSON document that it
-          does not recognize.
+          <code>PUT</code> request to the commit endpoint for the transaction.
         </p>
         <p>
           The effects of all requests in the series MUST become durable and MUST
@@ -290,7 +298,8 @@
         <p>
           The effects of all requests in the series MUST disappear to all
           clients, and MUST be durably gone. The transaction identifier URI of
-          the series MUST be expired and MUST NOT be reused.
+          the series MUST be expired and MUST NOT be reused. In addition, the
+          commit endpoint MUST be expired and MUST NOT be reused.
         </p>
         <p>
           If the server is able to successfully complete this request, it MUST

--- a/index.html
+++ b/index.html
@@ -90,8 +90,19 @@
     </section>
     <section id="conformance">
     </section>
-		<section id="terminology">
-		</section>
+    <section id="terminology">
+      <h2>Terminology</h2>
+      <dl>
+        <dt>transaction endpoint</dt>
+        <dd>an HTTP resource that supports operations to create a new
+        transaction</dd>
+        <dt>transaction root</dt>
+        <dd>the HTTP resource that a given transaction is scoped to</dd>
+        <dt>transaction identifier</dt>
+        <dd>a resolvable HTTP URI that uniquely identifies a transaction and
+        which supports operations to mangage that transaction</dd>
+      </dl>
+    </section>
     <section id ="atomic-operations">
       <h2>Atomic Operations</h2>
 
@@ -183,8 +194,9 @@
         <p>
           If the server is able to create the transaction, it MUST respond with
           a <code>201 Created</code> HTTP status and MUST include a
-          <code>Location</code> header that contains the <dfn>transaction
-          URI</dfn>.
+          <code>Location</code> header whose value is a <dfn>transaction
+          identifier</dfn>. A transaction identifier MUST be a resolvable HTTP
+          URI.
         </p>
       </section>
 
@@ -192,28 +204,31 @@
         <h2>Adding to an atomic series of operations</h2>
         <p>
           A client adds to an atomic batch operation by including an
-          <code>Atomic-ID</code> request header. The value of this header is an
-          active transaction URI.
+          <code>Atomic-ID</code> request header. The value of this header is a
+          transaction identifier.
         </p>
         <p>
           The effect of the request, if it has one, and if the request is
-          successful, MUST be visible to clients using that identifier to add to
-          this series of requests, as described here, until the series expires
-          or is finished. The effect of the request, if it has one, and if the
-          request is successful, SHOULD NOT be visible to clients not using that
-          identifier to add to this series of requests.  The effect of the
-          request MUST NOT be durable unless and until the series is
-          successfully <a href="#commit">finished</a>.
+          successful, MUST be visible to clients using the same transaction
+          identifier as the value of the <code>Atomic-ID</code> header, as
+          described here, until the series expires or is finished. The effect of
+          the request, if it has one, and if the request is successful, SHOULD
+          NOT be visible to clients not using that transaction identifier The
+          effect of the request MUST NOT be durable unless and until the series
+          is successfully <a href="#commit">finished</a>.
         </p>
         <p>
           If the request is successful, the server MUST include a
           <code>Link</code> response header whose value MUST be the current
-          transaction URI. The <code>rel</code> parameter MUST be [URI TBD].
+          transaction identifier. The <code>rel</code> parameter MUST be [URI
+          TBD].
         </p>
         <p>
           If the transaction identified by the <code>Atomic-ID</code> header is
           inactive, the server MUST NOT update any resources, and it MUST
-          respond with a <code>409 Conflict</code> HTTP status.
+          respond with a <code>409 Conflict</code> HTTP status. The server MAY
+          also include more information about the reason for rejecting the
+          request in the response body.
         </p>
       </section>
 
@@ -232,19 +247,19 @@
         </p>
         <p>
           An implementation SHOULD permit extending the lifetime of a series by
-          a <code>POST</code> request to the transaction URI.
+          a <code>POST</code> request to the transaction identifier URI.
       </section>
 
       <section id="commit">
         <h2>Committing a series</h2>
         <p>
           A client finishes an atomic series of requests by sending a
-          <code>PUT</code> request to the transaction URI.
+          <code>PUT</code> request to the transaction identifier URI.
         </p>
         <p>
           The effects of all requests in the series MUST become durable and MUST
-          become visible to all clients. The transaction URI of the series MUST
-          be expired and MUST NOT be reused.
+          become visible to all clients. The transaction identifier of the
+          series MUST be expired and MUST NOT be reused.
         </p>
       </section>
 
@@ -252,12 +267,12 @@
         <h2>Aborting a series</h2>
         <p>
           A client aborts an atomic series of requests by sending a
-          <code>DELETE</code> request to the transaction URI.
+          <code>DELETE</code> request to the transaction identifier URI.
         </p>
         <p>
           The effects of all requests in the series MUST disappear to all
-          clients, and MUST be durably gone. The transaction URI of the series
-          MUST be expired and MUST NOT be reused.
+          clients, and MUST be durably gone. The transaction identifier URI of
+          the series MUST be expired and MUST NOT be reused.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -209,17 +209,11 @@
           If the request is successful, the server MUST include a
           <code>Link</code> response header whose value MUST be the current
           transaction URI. The <code>rel</code> parameter MUST be [URI TBD].
-        <p>
-          If the client sending the current request is not authorized to access
-          the transaction identified by the <code>Atomic-ID</code> header, the
-          server MUST NOT update any resources, and MUST respond with a
-          <code>404 Not Found</code> HTTP status.
         </p>
         <p>
-          If the client is authorized but the transaction identified by the
-          <code>Atomic-ID</code> header is inactive, the server MUST NOT update
-          any resources, and it MUST respond with a <code>409 Conflict</code>
-          HTTP status.
+          If the transaction identified by the <code>Atomic-ID</code> header is
+          inactive, the server MUST NOT update any resources, and it MUST
+          respond with a <code>409 Conflict</code> HTTP status.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -102,16 +102,53 @@
           against a repository in an atomic fashion.
         </p>
         <pre class="http">
+          # Discover the transaction endpoint
+
           HEAD http://example.org/foo
 
           200 OK
           Link: &lt;http://example.org/foo/fcr:tx>; rel="[URI TBD]"
 
+          # Begin a transaction
 
           POST http://example.org/foo/fcr:tx
 
           201 Created
-          Location: http://example.org/foo/tx:01234567-89ab-cdef-0123-456789abcdef
+          Location: http://example.org/foo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+
+          # Create a new resource within the transaction
+
+          POST http://example.org/foo
+          Atomic-ID: http://example.org/foo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+
+          201 Created
+          Location: http://example.org/foo/abcdef01-2345-6789-abcd-ef0123456789
+          Link: &lt;http://example.org/foo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef>; rel="[URI TBD]"
+
+          # That resource is not visible outside of the transaction
+
+          HEAD http://example.org/foo/abcdef01-2345-6789-abcd-ef0123456789
+
+          404 Not Found
+
+          # But is visible within the transaction
+
+          HEAD http://example.org/foo/abcdef01-2345-6789-abcd-ef0123456789
+          Atomic-ID: http://example.org/foo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+
+          200 OK
+
+          # Commit the transaction
+
+          PUT http://example.org/foo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+
+          204 No Content
+
+          # Now the new resource is visible outside the transaction
+
+          HEAD http://example.org/foo/abcdef01-2345-6789-abcd-ef0123456789
+
+          200 OK
         </pre>
       </section>
 
@@ -145,39 +182,44 @@
         </p>
         <p>
           If the server is able to create the transaction, it MUST respond with
-          a <code>201 Created</code> HTTP status and include a
-          <code>Location</code> header that contains the <dfn>transaction base
-          URI</dfn>. The transaction base URI MUST be formed by appending a
-          unique <dfn>transaction identifier</dfn> to the transaction root URI.
+          a <code>201 Created</code> HTTP status and MUST include a
+          <code>Location</code> header that contains the <dfn>transaction
+          URI</dfn>.
         </p>
       </section>
 
       <section id="adding">
         <h2>Adding to an atomic series of operations</h2>
         <p>
-          A client adds to an atomic batch operation by sending requests to URIs
-          that are path-wise children of an active transaction base URI.
+          A client adds to an atomic batch operation by including an
+          <code>Atomic-ID</code> request header. The value of this header is an
+          active transaction URI.
         </p>
         <p>
           The effect of the request, if it has one, and if the request is
           successful, MUST be visible to clients using that identifier to add to
-          this series of requests, as described <a href="#adding">below</a>,
-          until the series expires or is finished. The effect of the request, if
-          it has one, and if the request is successful, SHOULD NOT be visible to
-          clients not using that identifier to add to this series of requests.
-          The effect of the request MUST NOT be durable unless and until the
-          series is successfully <a href="#commit">finished</a>.
+          this series of requests, as described here, until the series expires
+          or is finished. The effect of the request, if it has one, and if the
+          request is successful, SHOULD NOT be visible to clients not using that
+          identifier to add to this series of requests.  The effect of the
+          request MUST NOT be durable unless and until the series is
+          successfully <a href="#commit">finished</a>.
         </p>
         <p>
+          If the request is successful, the server MUST include a
+          <code>Link</code> response header whose value MUST be the current
+          transaction URI. The <code>rel</code> parameter MUST be [URI TBD].
+        <p>
           If the client sending the current request is not authorized to access
-          this transaction, the server MUST NOT update any resources, and MUST
-          respond with a <code>404 Not Found</code> HTTP status.
+          the transaction identified by the <code>Atomic-ID</code> header, the
+          server MUST NOT update any resources, and MUST respond with a
+          <code>404 Not Found</code> HTTP status.
         </p>
         <p>
           If the client is authorized but the transaction identified by the
-          transaction base URI is invalid, the server MUST NOT update any
-          resources, and it MUST respond with a <code>409 Conflict</code> HTTP
-          status.
+          <code>Atomic-ID</code> header is inactive, the server MUST NOT update
+          any resources, and it MUST respond with a <code>409 Conflict</code>
+          HTTP status.
         </p>
       </section>
 
@@ -191,23 +233,24 @@
         </p>
         <p>
           An implementation SHOULD extend the lifetime of a series upon the
-          receipt of any request to resources under the transaction base URI.
+          receipt of any request to resources within the scope of the
+          transaction.
         </p>
         <p>
           An implementation SHOULD permit extending the lifetime of a series by
-          a <code>POST</code> request to the transaction base URI.
+          a <code>POST</code> request to the transaction URI.
       </section>
 
       <section id="commit">
         <h2>Committing a series</h2>
         <p>
           A client finishes an atomic series of requests by sending a
-          <code>PUT</code> request to the transaction base URI.
+          <code>PUT</code> request to the transaction URI.
         </p>
         <p>
           The effects of all requests in the series MUST become durable and MUST
-          become visible to all clients. The unique identifier of the series
-          MUST be expired and MUST NOT be reused.
+          become visible to all clients. The transaction URI of the series MUST
+          be expired and MUST NOT be reused.
         </p>
       </section>
 
@@ -215,11 +258,11 @@
         <h2>Aborting a series</h2>
         <p>
           A client aborts an atomic series of requests by sending a
-          <code>DELETE</code> request to the transaction base URI.
+          <code>DELETE</code> request to the transaction URI.
         </p>
         <p>
           The effects of all requests in the series MUST disappear to all
-          clients, and MUST be durably gone. The unique identifier of the series
+          clients, and MUST be durably gone. The transaction URI of the series
           MUST be expired and MUST NOT be reused.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -215,10 +215,10 @@
         </p>
         <p>
           If the transaction identified by the <code>Atomic-ID</code> header is
-          inactive, the server MUST NOT update any resources, and it MUST
-          respond with a <code>409 Conflict</code> HTTP status. The server MAY
-          also include more information about the reason for rejecting the
-          request in the response body.
+          invalid for any reason, the server MUST NOT update any resources, and
+          it MUST respond with a <code>409 Conflict</code> HTTP status. The
+          server MAY also include more information about the reason for
+          rejecting the request in the response body.
         </p>
       </section>
 
@@ -247,9 +247,22 @@
           <code>PUT</code> request to the transaction identifier URI.
         </p>
         <p>
+          The request body of this request MAY be non-empty. If it is non-empty,
+          [TODO: should we specify? or leave it up to implementations; this
+          could be a place to include commit messages, author info, etc.]
+        </p>
+        <p>
           The effects of all requests in the series MUST become durable and MUST
           become visible to all clients. The transaction identifier of the
           series MUST be expired and MUST NOT be reused.
+        </p>
+        <p>
+          If the server is able to successfully complete this request, it MUST
+          respond with a <code>2xx</code>-series HTTP status.
+        </p>
+        <p>
+          If the server is unable to successfully complete this request, it MUST
+          respond with a <code>409 Conflict</code> HTTP status.
         </p>
       </section>
 
@@ -263,6 +276,14 @@
           The effects of all requests in the series MUST disappear to all
           clients, and MUST be durably gone. The transaction identifier URI of
           the series MUST be expired and MUST NOT be reused.
+        </p>
+        <p>
+          If the server is able to successfully complete this request, it MUST
+          respond with a <code>2xx</code>-series HTTP status.
+        </p>
+        <p>
+          If the server is unable to successfully complete this request, it MUST
+          respond with a <code>409 Conflict</code> HTTP status.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -96,11 +96,9 @@
         <dt>transaction endpoint</dt>
         <dd>an HTTP resource that supports operations to create a new
         transaction</dd>
-        <dt>transaction root</dt>
-        <dd>the HTTP resource that a given transaction is scoped to</dd>
         <dt>transaction identifier</dt>
-        <dd>a resolvable HTTP URI that uniquely identifies a transaction and
-        which supports operations to mangage that transaction</dd>
+        <dd>an HTTP resource that uniquely identifies a trasnaction, and which
+        may be used to perform operations on that transaction</dd>
       </dl>
     </section>
     <section id ="atomic-operations">
@@ -115,73 +113,66 @@
         <pre class="http">
           # Discover the transaction endpoint
 
-          HEAD http://example.org/foo
+          HEAD http://example.org/repo
 
           200 OK
-          Link: &lt;http://example.org/foo/fcr:tx>; rel="[URI TBD]"
+          Link: &lt;http://example.org/repo/fcr:tx>; rel="[URI TBD]"
 
           # Begin a transaction
 
-          POST http://example.org/foo/fcr:tx
+          POST http://example.org/repo/fcr:tx
 
           201 Created
-          Location: http://example.org/foo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+          Location: http://example.org/repo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
 
           # Create a new resource within the transaction
 
-          POST http://example.org/foo
-          Atomic-ID: http://example.org/foo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+          POST http://example.org/repo/container
+          Atomic-ID: http://example.org/repo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
 
           201 Created
-          Location: http://example.org/foo/abcdef01-2345-6789-abcd-ef0123456789
-          Link: &lt;http://example.org/foo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef>; rel="[URI TBD]"
+          Location: http://example.org/repo/container/abcdef01-2345-6789-abcd-ef0123456789
+          Atomic-ID: http://example.org/repo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
 
           # That resource is not visible outside of the transaction
 
-          HEAD http://example.org/foo/abcdef01-2345-6789-abcd-ef0123456789
+          HEAD http://example.org/repo/container/abcdef01-2345-6789-abcd-ef0123456789
 
           404 Not Found
 
           # But is visible within the transaction
 
-          HEAD http://example.org/foo/abcdef01-2345-6789-abcd-ef0123456789
-          Atomic-ID: http://example.org/foo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+          HEAD http://example.org/repo/container/abcdef01-2345-6789-abcd-ef0123456789
+          Atomic-ID: http://example.org/repo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
 
           200 OK
 
           # Commit the transaction
 
-          PUT http://example.org/foo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
+          PUT http://example.org/repo/fcr:tx/01234567-89ab-cdef-0123-456789abcdef
 
           204 No Content
 
           # Now the new resource is visible outside the transaction
 
-          HEAD http://example.org/foo/abcdef01-2345-6789-abcd-ef0123456789
+          HEAD http://example.org/repo/container/abcdef01-2345-6789-abcd-ef0123456789
 
           200 OK
         </pre>
       </section>
 
       <section id="scope">
-        <h2>Transaction scope</h2>
+        <h2>Transaction endpoint</h2>
         <p>
-          Transactions are scoped to a resource and its path-wise children. In
-          this context, the resource is known as the <dfn>transaction
-          root</dfn>. The URI of this resource is a <dfn>transaction root
-          URI</dfn>.
+          Transactions are created through a <dfn>transaction endpoint</dfn>.
+          The <dfn>transaction endpoint URI</dfn> MUST be a resolvable HTTP URI.
         </p>
-      </section>
-
-      <section id="identify">
-        <h2>Advertising support for atomic operations</h2>
         <p>
           A server that supports atomic operations MUST advertise this support
-          by including a <code>Link</code> header in responses to requests to
-          resources that can be transaction roots. The value of this link
-          header MUST be a resolvable HTTP URI. This URI is known as the
-          <dfn>transaction endpoint</dfn>. The <code>rel</code> parameter of
-          this header MUST be [URI TBD].
+          by including a <code>Link</code> header in responses to requests for
+          the repository root. The value of this link MUST be the transaction
+          endpoint URI. The <code>rel</code> parameter of this header MUST be
+          <code>http://fedora.info/definitions/v4/transaction#endpoint</code>.
         </p>
       </section>
 
@@ -219,9 +210,8 @@
         </p>
         <p>
           If the request is successful, the server MUST include a
-          <code>Link</code> response header whose value MUST be the current
-          transaction identifier. The <code>rel</code> parameter MUST be [URI
-          TBD].
+          <code>Atomic-ID</code> response header whose value MUST be the current
+          transaction identifier.
         </p>
         <p>
           If the transaction identified by the <code>Atomic-ID</code> header is

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
           specStatus: "unofficial",
           shortName:  "fedora-abo",
           includePermalinks: true,
-          editors: [
+          formerEditors: [
                 {   name:       "Ben Armintor",
                     company:    "Columbia University",
                     companyURL: "http://library.columbia.edu/"},
@@ -51,6 +51,11 @@
                 {   name:       "Andrew Woods",
                     company:    "DuraSpace",
                     companyURL: "http://duraspace.org/"}
+          ],
+          editors: [
+                {   name:       "Peter Eichman",
+                    company:    "University of Maryland",
+                    companyURL: "https://www.lib.umd.edu/"}
           ],
           edDraftURI: "https://fcrepo.github.io/fcrepo-specification-atomic-operations/",
           testSuiteURI: "https://github.com/fcrepo/fcrepo-tcks",
@@ -93,80 +98,129 @@
       <section id="atomic-operations-introduction" class="informative">
         <h2>Introduction</h2>
         <p>
-          Fedora provides factilities by which to conduct multiple operations against a repository
-          in an atomic fashion. This is accomplished by the use of headers on requests. An atomic
-          series of operations should not require any more requests than the same series of
-          operations performed non-atomically.
+          Fedora provides factilities by which to conduct multiple operations
+          against a repository in an atomic fashion.
+        </p>
+        <pre class="http">
+          HEAD http://example.org/foo
+
+          200 OK
+          Link: &lt;http://example.org/foo/fcr:tx>; rel="[URI TBD]"
+
+
+          POST http://example.org/foo/fcr:tx
+
+          201 Created
+          Location: http://example.org/foo/tx:01234567-89ab-cdef-0123-456789abcdef
+        </pre>
+      </section>
+
+      <section id="scope">
+        <h2>Transaction scope</h2>
+        <p>
+          Transactions are scoped to a resource and its path-wise children. In
+          this context, the resource is known as the <dfn>transaction
+          root</dfn>. The URI of this resource is a <dfn>transaction root
+          URI</dfn>.
+        </p>
+      </section>
+
+      <section id="identify">
+        <h2>Advertising support for atomic operations</h2>
+        <p>
+          A server that supports atomic operations MUST advertise this support
+          by including a <code>Link</code> header in responses to requests to
+          resources that can be transaction roots. The value of this link
+          header MUST be a resolvable HTTP URI. This URI is known as the
+          <dfn>transaction endpoint</dfn>. The <code>rel</code> parameter of
+          this header MUST be [URI TBD].
         </p>
       </section>
 
       <section id="begin">
         <h2>Beginning an atomic series of operations</h2>
         <p>
-          A client begins an atomic series of requests by sending any request to any resource with
-          the header <code>Atomic-Start</code>. The server MUST respond by including a header
-          <code>Atomic-ID</code> with a unique identifier for the series. The effect of the
-          request, if it has one, and if the request is successful, MUST be visible to clients
-          using that identifier to add to this series of requests, as described
-          <a href="#adding">below</a>, until the series expires or is finished. The effect of the
-          request, if it has one, and if the request is successful, SHOULD NOT be visible to
-          clients not using that identifier to add to this series of requests. The effect of the
-          request MUST NOT be durable unless and until the series is successfully
-          <a href="#commit">finished</a>.
+          A client begins an atomic series of requests by sending a POST request
+          to a transaction endpoint.
+        </p>
+        <p>
+          If the server is able to create the transaction, it MUST respond with
+          a <code>201 Created</code> HTTP status and include a
+          <code>Location</code> header that contains the <dfn>transaction base
+          URI</dfn>. The transaction base URI MUST be formed by appending a
+          unique <dfn>transaction identifier</dfn> to the transaction root URI.
         </p>
       </section>
 
       <section id="adding">
         <h2>Adding to an atomic series of operations</h2>
         <p>
-          A client adds to an atomic series of requests by sending any request to any resource with
-          the header <code>Atomic-ID</code> and the identifier for that series. The effect of the
-          request, if it has one, and if the request is successful, MUST be visible to clients
-          using that identifier to add to this series of requests, until the series expires or is
-          finished. The effect of the request, if it has one, and if the request is successful,
-          SHOULD NOT be visible to clients not using that identifier to add to this series of
-          requests. The effect of the request MUST NOT be durable unless and until the series is
-          successfully <a href="#commit">finished</a>. An implementation MUST respond
-          to any request with multiple <code>Atomic-ID</code> headers with different values or
-          with an <code>Atomic-ID</code> header with a value that has not been assigned to a
-          series or that has expired (see <a href="#expiration">below</a>) with a 409 response.
-          That response MUST include an <code>Atomic-Invalid</code> header or headers with the
-          invalid identifier or identifiers.
+          A client adds to an atomic batch operation by sending requests to URIs
+          that are path-wise children of an active transaction base URI.
+        </p>
+        <p>
+          The effect of the request, if it has one, and if the request is
+          successful, MUST be visible to clients using that identifier to add to
+          this series of requests, as described <a href="#adding">below</a>,
+          until the series expires or is finished. The effect of the request, if
+          it has one, and if the request is successful, SHOULD NOT be visible to
+          clients not using that identifier to add to this series of requests.
+          The effect of the request MUST NOT be durable unless and until the
+          series is successfully <a href="#commit">finished</a>.
+        </p>
+        <p>
+          If the client sending the current request is not authorized to access
+          this transaction, the server MUST NOT update any resources, and MUST
+          respond with a <code>404 Not Found</code> HTTP status.
+        </p>
+        <p>
+          If the client is authorized but the transaction identified by the
+          transaction base URI is invalid, the server MUST NOT update any
+          resources, and it MUST respond with a <code>409 Conflict</code> HTTP
+          status.
         </p>
       </section>
 
       <section id="expiration">
         <h2>Expiration</h2>
         <p>
-          An implementation MAY enforce automatic expiration for an atomic series of requests.
-          If so, the response to any request made as part of the series MUST have a
-          <code>Atomic-Expires</code> header with the HTTP datetime at which the series will
-          expire. An implementation MAY extend the lifetime of a series upon the receipt of any
-          request specifying the unique identifier of that series in the <code>Atomic-ID</code>
-          header.
+          An implementation MAY enforce automatic expiration for an atomic
+          series of requests.  If so, the response to any request made as part
+          of the series MUST have a <code>Atomic-Expires</code> header with the
+          HTTP datetime at which the series will expire.
         </p>
+        <p>
+          An implementation SHOULD extend the lifetime of a series upon the
+          receipt of any request to resources under the transaction base URI.
+        </p>
+        <p>
+          An implementation SHOULD permit extending the lifetime of a series by
+          a <code>POST</code> request to the transaction base URI.
       </section>
 
       <section id="commit">
         <h2>Committing a series</h2>
         <p>
-          A client can finish an atomic series of requests by sending any
-          <code>PUT</code>/<code>POST</code>/<code>PATCH</code>/<code>DELETE</code> request
-          including both a <code>Atomic-Commit</code> header and a <code>Atomic-ID</code>
-          header with the unique identifier of an existing series. The effects of all requests
-          in the series MUST become durable and MUST become visible to all clients. The unique
-          identifier of the series MUST be expired and MUST NOT be reused.
+          A client finishes an atomic series of requests by sending a
+          <code>PUT</code> request to the transaction base URI.
+        </p>
+        <p>
+          The effects of all requests in the series MUST become durable and MUST
+          become visible to all clients. The unique identifier of the series
+          MUST be expired and MUST NOT be reused.
         </p>
       </section>
 
       <section id="abort">
         <h2>Aborting a series</h2>
         <p>
-          A client can finish an atomic series of requests by sending any request including
-          both a <code>Atomic-Abort</code> header and a <code>Atomic-ID</code> header with
-          the unique identifier of an existing series. The effects of all requests in the
-          series MUST disappear to all clients, and MUST be durably gone. The unique identifier
-          of the series MUST be expired and MUST NOT be reused.
+          A client aborts an atomic series of requests by sending a
+          <code>DELETE</code> request to the transaction base URI.
+        </p>
+        <p>
+          The effects of all requests in the series MUST disappear to all
+          clients, and MUST be durably gone. The unique identifier of the series
+          MUST be expired and MUST NOT be reused.
         </p>
       </section>
     </section>


### PR DESCRIPTION
This is a very rough first draft of switching from the header-based transaction identifiers to scoping transactions via URL paths. This approach is similar to the way the Fedora 4 and 5 Java Modeshape-based implementations work.